### PR TITLE
Fix hardcoded temp directory path

### DIFF
--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -98,14 +98,9 @@ func SanitizeFilename(name string) string {
 
 // createJobTempDir creates a temporary directory for a job
 func (s *Server) createJobTempDir(jobID string) string {
-	tempDir := filepath.Join("/tmp", "djset-server-jobs", jobID)
+	tempDir := filepath.Join(os.TempDir(), "djset-server-jobs", jobID)
 	if err := os.MkdirAll(tempDir, 0755); err != nil {
 		slog.Error("Failed to create temp directory", "dir", tempDir, "error", err)
-		// Fall back to system temp directory
-		tempDir = filepath.Join(os.TempDir(), "djset-server-jobs", jobID)
-		if err := os.MkdirAll(tempDir, 0755); err != nil {
-			slog.Error("Failed to create fallback temp directory", "dir", tempDir, "error", err)
-		}
 	}
 	return tempDir
 }


### PR DESCRIPTION
Use `os.TempDir()` in `createJobTempDir` to ensure cross-platform compatibility and prevent unnecessary directory creation failures on Windows.