### PR TITLE
Fix array index validation in downloadTrack

### DIFF
--- a/internal/server/download_handlers.go
+++ b/internal/server/download_handlers.go
@@ -48,6 +48,10 @@ func (s *Server) downloadAllTracks(c *gin.Context) {
 
 	// Add each track to the ZIP
 	for i, trackPath := range jobStatus.Results {
+		if i >= len(jobStatus.Tracklist.Tracks) {
+			c.JSON(500, gin.H{"error": fmt.Sprintf("Track %d metadata not found", i+1)})
+			return
+		}
 		if err := s.addFileToZip(zipWriter, trackPath, i+1, jobStatus.Tracklist.Tracks[i]); err != nil {
 			c.JSON(500, gin.H{"error": fmt.Sprintf("Failed to add track %d to ZIP: %v", i+1, err)})
 			return
@@ -77,7 +81,7 @@ func (s *Server) downloadTrack(c *gin.Context) {
 		return
 	}
 
-	if trackNumber < 1 || trackNumber > len(jobStatus.Results) {
+	if trackNumber < 1 || trackNumber > len(jobStatus.Results) || trackNumber > len(jobStatus.Tracklist.Tracks) {
 		c.JSON(404, gin.H{"error": "Track not found"})
 		return
 	}


### PR DESCRIPTION
Fix array index out of bounds panic in `downloadTrack` and `downloadAllTracks` by adding proper bounds checks for `jobStatus.Tracklist.Tracks`.