### PR TITLE
Fix failing tests

### DIFF
--- a/internal/server/job_handlers.go
+++ b/internal/server/job_handlers.go
@@ -75,8 +75,11 @@ func (s *Server) getJobStatus(c *gin.Context) {
 
 		// Create a copy of the tracklist to avoid modifying the original
 		tracklistCopy := jobStatus.Tracklist
-		tracksCopy := make([]domain.Track, len(tracklistCopy.Tracks))
-		copy(tracksCopy, tracklistCopy.Tracks)
+		tracksCopy := make([]*domain.Track, len(tracklistCopy.Tracks))
+		for i, track := range tracklistCopy.Tracks {
+			trackCopy := *track
+			tracksCopy[i] = &trackCopy
+		}
 		tracklistCopy.Tracks = tracksCopy
 		jobStatus.Tracklist = tracklistCopy
 


### PR DESCRIPTION
Fix compilation error in `job_handlers.go` by correcting type mismatch during tracklist copying.

The previous code attempted to `copy` a `[]*domain.Track` into a `[]domain.Track`, leading to a compilation error due to incompatible element types. This PR introduces a loop to create a deep copy of `domain.Track` objects and store them as pointers in the new slice, resolving the type mismatch and ensuring all tests pass.